### PR TITLE
feat: Added retry behaviour by missing network

### DIFF
--- a/p1_influx_db/dsmr_parse.py
+++ b/p1_influx_db/dsmr_parse.py
@@ -134,7 +134,7 @@ class dsmrParse:
         parsed_telegram: Dict[str, any],
         keylist: List[str],
         message: p1Messages,
-        p1MessageList: List[p1Messages],
+        p1MessageList: List[dsmrMessages],
         unitCheck: str,
         topic: str,
     ):

--- a/p1_influx_db/mqtt/__init__.py
+++ b/p1_influx_db/mqtt/__init__.py
@@ -1,1 +1,2 @@
 from .client import MqttClient as Client
+from .message_store import MessageStore

--- a/p1_influx_db/mqtt/__init__.py
+++ b/p1_influx_db/mqtt/__init__.py
@@ -1,2 +1,1 @@
 from .client import MqttClient as Client
-from .message_store import MessageStore

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -44,8 +44,8 @@ class MqttClient(mqtt.Client):
         self.on_publish = on_publish_handler
 
     def start(self):
-        self.connect(self.broker, self.port, clean_start=mqtt.MQTT_CLEAN_START_FIRST_ONLY)
         self.loop_start()
+        self.connect(self.broker, self.port, clean_start=mqtt.MQTT_CLEAN_START_FIRST_ONLY)
 
     def stop(self):
         self.loop_stop()
@@ -70,11 +70,14 @@ class MqttClient(mqtt.Client):
 
     def reconnect_loop(self):
         times = 0
-        while times < 60:
+        while times < 5:
             try:
-                self.reconnect()
+                self.start()
                 break
             except Exception as e:
                 logger.error(f"Reconnect failed: {e}")
                 times += 1
                 time.sleep(5)  # Wait before retrying to reconnect
+        if times >= 5:
+            logger.error("Failed to reconnect after multiple attempts.")
+            raise Exception("Failed to reconnect after multiple attempts.")

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -83,4 +83,6 @@ class MqttClient(mqtt.Client):
                 time.sleep(5)  # Wait before retrying to reconnect
         if self.times >= 2:
             logger.error("Failed to reconnect after multiple attempts.")
+            self.stop()
+            self.loop_stop()
             raise ConnectionError("Failed to reconnect after multiple attempts.")

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -4,6 +4,8 @@ import ssl
 import time
 from p1_influx_db.mqtt.message_store import MessageStore
 
+import os
+
 
 def on_connect_handler(client, userdata, flags, rc, properties):
     logger.debug("Connected with result code " + str(rc))
@@ -85,4 +87,4 @@ class MqttClient(mqtt.Client):
             logger.error("Failed to reconnect after multiple attempts.")
             self.stop()
             self.loop_stop()
-            raise SystemExit(1)
+            raise os._exit(1)

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -2,7 +2,7 @@ import paho.mqtt.client as mqtt
 from loguru import logger
 import ssl
 import time
-from message_store import MessageStore
+from p1_influx_db.mqtt import MessageStore
 
 
 class MqttClient(mqtt.Client):

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -41,6 +41,7 @@ class MqttClient(mqtt.Client):
         logger.warning("Disconnected with result code " + str(rc))
         if rc != 0:
             logger.info("Unexpected disconnection. Attempting to reconnect...")
+            time.sleep(5)
             self.reconnect()
 
     def on_publish_handler(self, client, userdata, mid):
@@ -63,12 +64,3 @@ class MqttClient(mqtt.Client):
             logger.info(f"Resending message to topic {topic}")
             self.publish_messages(topic, payload)
             time.sleep(1)  # Optional delay between resends
-
-    def reconnect(self):
-        while True:
-            try:
-                self.reconnect()
-                break
-            except Exception as e:
-                logger.error(f"Reconnect failed: {e}")
-                time.sleep(5)  # Wait before retrying to reconnect

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -26,6 +26,8 @@ def on_publish_handler(client, userdata, mid, rc, properties):
 
 def handle_exceptions(e):
     print(traceback.print_exception(e.exc_type, e.exc_value, e.exc_traceback))
+    raise Exception(f"Unhandled exception in thread: {e.exc_type.__name__}: {e.exc_value}") from e.exc_value
+
 
 class MqttClient(mqtt.Client):
     def __init__(self, broker, port, client_id, ca_certs, certfile, key):

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -2,7 +2,7 @@ import paho.mqtt.client as mqtt
 from loguru import logger
 import ssl
 import time
-from p1_influx_db.mqtt import MessageStore
+from p1_influx_db.mqtt.message_store import MessageStore
 
 
 class MqttClient(mqtt.Client):

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -15,7 +15,7 @@ def on_disconnect_handler(client, userdata, flags, rc, properties):
     if rc != 0:
         logger.info("Unexpected disconnection. Attempting to reconnect...")
         time.sleep(5)
-        client.reconnect()
+        client.reconnect_loop()
 
 
 def on_publish_handler(client, userdata, mid, rc, properties):
@@ -67,3 +67,14 @@ class MqttClient(mqtt.Client):
             logger.info(f"Resending message to topic {topic}")
             self.publish_messages(topic, payload)
             time.sleep(1)  # Optional delay between resends
+
+    def reconnect_loop(self):
+        times = 0
+        while times < 60:
+            try:
+                self.reconnect()
+                break
+            except Exception as e:
+                logger.error(f"Reconnect failed: {e}")
+                times += 1
+                time.sleep(5)  # Wait before retrying to reconnect

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -51,6 +51,7 @@ class MqttClient(mqtt.Client):
         self.loop_stop()
 
     def publish_messages(self, topic, payload):
+        topic = f"p1/{topic}"
         message_info = self.publish(topic, payload, qos=1)
         if message_info.rc == mqtt.MQTT_ERR_NO_CONN:
             logger.error("Not connected. Storing message for later.")
@@ -70,7 +71,7 @@ class MqttClient(mqtt.Client):
 
     def reconnect_loop(self):
         times = 0
-        while times < 5:
+        while times < 60:
             try:
                 self.start()
                 break
@@ -78,6 +79,6 @@ class MqttClient(mqtt.Client):
                 logger.error(f"Reconnect failed: {e}")
                 times += 1
                 time.sleep(5)  # Wait before retrying to reconnect
-        if times >= 5:
+        if times >= 60:
             logger.error("Failed to reconnect after multiple attempts.")
             raise Exception("Failed to reconnect after multiple attempts.")

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -71,9 +71,9 @@ class MqttClient(mqtt.Client):
             time.sleep(1)  # Optional delay between resends
 
     def reconnect_loop(self):
-        logger.info(f"Attempting to reconnect, times: {self.times}")
         while self.times < 2:
             try:
+                logger.info(f"Attempting to reconnect, times: {self.times}")
                 self.start()
                 self.times = 0
                 break

--- a/p1_influx_db/mqtt/client.py
+++ b/p1_influx_db/mqtt/client.py
@@ -1,8 +1,10 @@
+import traceback
 import paho.mqtt.client as mqtt
 from loguru import logger
 import ssl
 import time
 from p1_influx_db.mqtt.message_store import MessageStore
+import threading
 
 
 def on_connect_handler(client, userdata, flags, rc, properties):
@@ -21,6 +23,9 @@ def on_disconnect_handler(client, userdata, flags, rc, properties):
 def on_publish_handler(client, userdata, mid, rc, properties):
     logger.debug(f"Message {mid} published.")
 
+
+def handle_exceptions(e):
+    print(traceback.print_exception(e.exc_type, e.exc_value, e.exc_traceback))
 
 class MqttClient(mqtt.Client):
     def __init__(self, broker, port, client_id, ca_certs, certfile, key):
@@ -86,3 +91,6 @@ class MqttClient(mqtt.Client):
             self.stop()
             self.loop_stop()
             raise ConnectionError("Failed to reconnect after multiple attempts.")
+
+
+threading.excepthook = handle_exceptions

--- a/p1_influx_db/mqtt/message_store.py
+++ b/p1_influx_db/mqtt/message_store.py
@@ -1,0 +1,19 @@
+class MessageStore:
+    def __init__(self):
+        self.message_queue = []
+
+    def add_message(self, topic, payload):
+        self.message_queue.append((topic, payload))
+
+    def retrieve_messages(self):
+        messages_to_send = self.message_queue.copy()
+        self.message_queue.clear()
+        return messages_to_send
+
+    def has_messages(self):
+        return len(self.message_queue) > 0
+
+    def get_message(self):
+        if self.message_queue:
+            return self.message_queue.pop(0)
+        return None

--- a/p1_influx_db/mqtt/utils.py
+++ b/p1_influx_db/mqtt/utils.py
@@ -1,0 +1,14 @@
+from loguru import logger
+
+
+def format_message(topic, payload):
+    return {"topic": topic, "payload": payload}
+
+
+def handle_mqtt_error(client, userdata, msg):
+    logger.error(f"MQTT Error: {msg}")
+
+
+def validate_message_format(message):
+    if not isinstance(message, dict) or "topic" not in message or "payload" not in message:
+        raise ValueError("Invalid message format. Must be a dict with 'topic' and 'payload' keys.")

--- a/p1_influx_db/mqttmain.py
+++ b/p1_influx_db/mqttmain.py
@@ -46,6 +46,12 @@ def mqttmain(config: Dict[str, Any]):
     try:
         for telegram in serial_reader.read_as_object():
             dead_queue = read_and_publish_p1(telegram, dsmrParser, client, dead_queue)
+            if dead_queue:
+                try:
+                    client.reconnect()
+                except ConnectionRefusedError:
+                    logger.error("Connection refused, trying again in 5 seconds")
+                    continue
             if len(dead_queue) > 2000:
                 raise RuntimeError("Dead queue is larger than 2000")
     except Exception as e:

--- a/p1_influx_db/mqttmain.py
+++ b/p1_influx_db/mqttmain.py
@@ -4,31 +4,9 @@ from typing import Dict, List, Any
 from dsmr_parser import telegram_specifications
 from dsmr_parser.clients import SerialReader, SERIAL_SETTINGS_V5
 
-from p1_influx_db.dsmr_parse import dsmrParse, p1Messages
+from p1_influx_db.dsmr_parse import dsmrParse
 
 from p1_influx_db.mqtt import Client
-
-
-def read_and_publish_p1(telegram, dsmrParser: dsmrParse, client: Client, dead_queue: List[p1Messages]):
-    info_list = dsmrParser.parse_dsmr_telegram(telegram)
-    for dsmr_message in info_list:
-        try:
-            client.publish_messages(dsmr_message)
-        except RuntimeError as e:
-            logger.error(f"Runtime error: {e}")
-            dead_queue.append(dsmr_message)
-    loop_dead_queue = dead_queue.copy()
-    for message in loop_dead_queue:
-        try:
-            error = False
-            client.publish_messages(message)
-        except RuntimeError as e:
-            error = True
-            logger.error(f"Runtime error: {e}")
-        finally:
-            if not error:
-                dead_queue.remove(message)
-    return dead_queue
 
 
 def mqttmain(config: Dict[str, Any]):
@@ -42,18 +20,14 @@ def mqttmain(config: Dict[str, Any]):
         serial_settings=SERIAL_SETTINGS_V5,
         telegram_specification=telegram_specifications.V5,
     )
-    dead_queue = []
     try:
         for telegram in serial_reader.read_as_object():
-            dead_queue = read_and_publish_p1(telegram, dsmrParser, client, dead_queue)
-            if dead_queue:
-                try:
-                    client.reconnect()
-                except ConnectionRefusedError:
-                    logger.error("Connection refused, trying again in 5 seconds")
-                    continue
-            if len(dead_queue) > 2000:
-                raise RuntimeError("Dead queue is larger than 2000")
+            info_list = dsmrParser.parse_dsmr_telegram(telegram)
+            for dsmr_message in info_list:
+                topic = dsmr_message.topic
+                payload = dsmr_message.payload.model_dump_json()
+                client.publish_messages(topic, payload)
+
     except Exception as e:
         client.stop()
         logger.info("Closing MqttClient")


### PR DESCRIPTION
This pull request includes significant updates to the MQTT client implementation in the `p1_influx_db` project. The changes improve the handling of MQTT connections, message storage, and error management. Below are the most important changes:

### MQTT Client Enhancements:

* [`p1_influx_db/mqtt/client.py`](diffhunk://#diff-8a1d22b701652cb3fdd665d20cf2006cf52b0626ca33b72480e0e669064d58deR4-R24): Added new connection, disconnection, and publish handlers to improve the robustness of the MQTT client. Introduced methods for reconnecting and resending messages. [[1]](diffhunk://#diff-8a1d22b701652cb3fdd665d20cf2006cf52b0626ca33b72480e0e669064d58deR4-R24) [[2]](diffhunk://#diff-8a1d22b701652cb3fdd665d20cf2006cf52b0626ca33b72480e0e669064d58deR33-R36) [[3]](diffhunk://#diff-8a1d22b701652cb3fdd665d20cf2006cf52b0626ca33b72480e0e669064d58deR45-R90)

### Message Storage:

* [`p1_influx_db/mqtt/message_store.py`](diffhunk://#diff-ede09486a522e9170aa2e12ad5f620788dd79237d6c5aadf7ae21875fdf42e5eR1-R19): Created a `MessageStore` class to handle message queuing and retrieval, which ensures messages are not lost during disconnections.

### Utility Functions:

* [`p1_influx_db/mqtt/utils.py`](diffhunk://#diff-a14ef710476b540b0fcf1ca6b83d9b2860e7c02f361e28db5449321dce723968R1-R14): Added utility functions for formatting messages, handling MQTT errors, and validating message formats.

### Refactoring:

* [`p1_influx_db/dsmr_parse.py`](diffhunk://#diff-0197e94870249049150039a7a97804a9c347e65c0b9105bfa6cdb3fccae57b7dL137-R137): Updated the type of `p1MessageList` parameter from `List[p1Messages]` to `List[dsmrMessages]` for better type consistency.
* [`p1_influx_db/mqttmain.py`](diffhunk://#diff-d7f5ca8fc30e7c5be31880e2f9499fdb0a7a3f073974c2a88eec5ff03f260acfL7-L33): Simplified the `mqttmain` function by removing the dead queue and directly publishing parsed messages. [[1]](diffhunk://#diff-d7f5ca8fc30e7c5be31880e2f9499fdb0a7a3f073974c2a88eec5ff03f260acfL7-L33) [[2]](diffhunk://#diff-d7f5ca8fc30e7c5be31880e2f9499fdb0a7a3f073974c2a88eec5ff03f260acfL45-R30)